### PR TITLE
Add --workingdir argument

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import './loaders/loops';
 import './loaders/arguments';
+import './loaders/state';
 import './services/openApp';
 import './api';
 

--- a/src/loaders/arguments.ts
+++ b/src/loaders/arguments.ts
@@ -17,7 +17,17 @@ const argv = yargs(process.argv)
       alias: 'p',
       type: 'number',
       description: 'Change the port to access the ui',
+    })
+    .option('workingdir', {
+      alias: 'w',
+      type: 'string',
+      description: 'Change the working directory where config and state is stored',
     }).argv;
+
+if (argv.workingdir) {
+  state.setWorkingDir(argv.workingdir);
+  console.log('Config dir overrided to: '+state.workingDir);
+}
 
 if (argv.debug) {
   state.setDebugMode(true);

--- a/src/loaders/arguments.ts
+++ b/src/loaders/arguments.ts
@@ -1,6 +1,7 @@
 import state from '../services/state';
 import dLog from '../utilities/debugLog';
 import yargs from 'yargs/yargs';
+import chalk from 'chalk';
 
 const argv = yargs(process.argv)
     .option('debug', {
@@ -25,8 +26,12 @@ const argv = yargs(process.argv)
     }).argv;
 
 if (argv.workingdir) {
-  state.setWorkingDir(argv.workingdir);
-  console.log('Config dir overrided to: '+state.workingDir);
+  try {
+    state.setWorkingDir(argv.workingdir);
+    console.log(chalk.green('Config dir override:'), state.workingDir);
+  } catch {
+    console.log(chalk.red('Invalid working directory provided, defaulting to:'), state.workingDir)
+  }
 }
 
 if (argv.debug) {

--- a/src/loaders/state.ts
+++ b/src/loaders/state.ts
@@ -1,0 +1,6 @@
+import state from '../services/state';
+
+/**
+ * Loads config and state from files
+ */
+state.initState();

--- a/src/services/state.ts
+++ b/src/services/state.ts
@@ -5,8 +5,6 @@ import {join} from 'path';
 const packageRaw = readFileSync(join(__dirname, '../../..', './package.json'));
 const packageJson = JSON.parse(packageRaw.toString());
 
-const cwd = process.cwd();
-
 /**
  * Handles the state across Bar 3
  */
@@ -20,6 +18,7 @@ class StateHandler {
   public debug = false;
   public headless = false;
   public port = 8055;
+  public workingDir = process.cwd();
   public serverVersion = packageJson.version;
 
   /**
@@ -37,7 +36,7 @@ class StateHandler {
   writeConfig(config: Config) {
     this.config = config;
     try {
-      writeFileSync(join(cwd, './config.json'), JSON.stringify(config));
+      writeFileSync(join(this.workingDir, './config.json'), JSON.stringify(config));
       this.isSetup = true;
     } catch {
       console.error('Can\'t write config!');
@@ -49,7 +48,7 @@ class StateHandler {
    */
   writeApplicationState() {
     try {
-      writeFileSync(join(cwd, './state.json'), JSON.stringify({
+      writeFileSync(join(this.workingDir, './state.json'), JSON.stringify({
         isApplicationOn: this.isApplicationOn,
       }));
     } catch {
@@ -62,7 +61,7 @@ class StateHandler {
    */
   loadApplicationState() {
     try {
-      const rawConfig = readFileSync(join(cwd, './state.json')).toString();
+      const rawConfig = readFileSync(join(this.workingDir, './state.json')).toString();
       this.isApplicationOn = JSON.parse(rawConfig).isApplicationOn;
     } catch {
       console.error('Can\'t load state!');
@@ -74,7 +73,7 @@ class StateHandler {
    */
   private loadConfig() {
     try {
-      const rawConfig = readFileSync(join(cwd, './config.json')).toString();
+      const rawConfig = readFileSync(join(this.workingDir, './config.json')).toString();
       this.config = JSON.parse(rawConfig);
       this.isSetup = true;
     } catch {
@@ -138,6 +137,20 @@ class StateHandler {
    */
   setPort(port: number) {
     this.port = port;
+  }
+
+  /**
+   * Sets the working directory and reloads state and config
+   * @param {string} dir The working directory to change to
+   */
+  setWorkingDir(dir: string) {
+    // Change directory
+    process.chdir(dir);
+    this.workingDir = process.cwd();
+
+    // Reload config
+    this.loadConfig();
+    this.loadApplicationState();
   }
 }
 


### PR DESCRIPTION
Useful for running multiple instances, `--workingdir <folder path>` points the server to a custom working directory location, where it will look for `config.json` and `state.json` files.

This solves the issue of storing a separate 70MB binary for each instance